### PR TITLE
Fix persistent chat log display

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,8 +79,9 @@ select{padding:10px}
 .composer input::placeholder{color:#6f9189}
 
 /* Ensure chat UI is only visible when Chat screen is active */
-.chat-log, #screenChat .composer{display:none !important}
-#screenChat.active .chat-log, #screenChat.active .composer{display:flex !important}
+#screenChat .chat-log, #screenChat .composer{display:none !important}
+#screenChat.active .chat-log{display:block !important}
+#screenChat.active .composer{display:flex !important}
 
 /* Animations */
 @keyframes popIn{0%{opacity:0;transform:translateY(6px) scale(.95)}100%{opacity:1;transform:none}}


### PR DESCRIPTION
Adjust CSS to prevent chat log from persisting across tabs and fix its display within the chat screen.

---
<a href="https://cursor.com/background-agent?bcId=bc-c9628d4a-8029-4559-bca0-0ecfc49f5d1a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c9628d4a-8029-4559-bca0-0ecfc49f5d1a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

